### PR TITLE
Add Support for Mac Address

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -110,7 +110,7 @@ class Client(requests.Session):
                           network_disabled=False, entrypoint=None,
                           cpu_shares=None, working_dir=None,
                           domainname=None, memswap_limit=0, cpuset=None,
-                          host_config=None):
+                          host_config=None, mac_address=None):
         if isinstance(command, six.string_types):
             command = shlex.split(str(command))
         if isinstance(environment, dict):
@@ -227,7 +227,8 @@ class Client(requests.Session):
             'Cpuset': cpuset,
             'WorkingDir': working_dir,
             'MemorySwap': memswap_limit,
-            'HostConfig': host_config
+            'HostConfig': host_config,
+            'MacAddress': mac_address
         }
 
     def _post_json(self, url, data, **kwargs):
@@ -539,7 +540,8 @@ class Client(requests.Session):
                          volumes=None, volumes_from=None,
                          network_disabled=False, name=None, entrypoint=None,
                          cpu_shares=None, working_dir=None, domainname=None,
-                         memswap_limit=0, cpuset=None, host_config=None):
+                         memswap_limit=0, cpuset=None, host_config=None,
+                         mac_address=None):
 
         if isinstance(volumes, six.string_types):
             volumes = [volumes, ]
@@ -551,7 +553,7 @@ class Client(requests.Session):
             image, command, hostname, user, detach, stdin_open, tty, mem_limit,
             ports, environment, dns, volumes, volumes_from, network_disabled,
             entrypoint, cpu_shares, working_dir, domainname,
-            memswap_limit, cpuset, host_config
+            memswap_limit, cpuset, host_config, mac_address
         )
         return self.create_container_from_config(config, name)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -204,6 +204,7 @@ from. Optionally a single string joining container id's with commas
 * domainname (str or list): Set custom DNS search domains
 * memswap_limit (int):
 * host_config (dict): A [HostConfig](hostconfig.md) dictionary
+* mac_address (str): The Mac Address to assign the container
 
 **Returns** (dict): A dictionary with an image 'Id' key and a 'Warnings' key.
 

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -129,6 +129,7 @@ def get_fake_inspect_container():
             "StartedAt": "2013-09-25T14:01:18.869545111+02:00",
             "Ghost": False
         },
+        "MacAddress": "02:42:ac:11:00:0a"
     }
     return status_code, response
 
@@ -188,7 +189,8 @@ def get_fake_port():
             'Ports': {
                 '1111': None,
                 '1111/tcp': [{'HostIp': '127.0.0.1', 'HostPort': '4567'}],
-                '2222': None}
+                '2222': None},
+            'MacAddress': '02:42:ac:11:00:0a'
         }
     }
     return status_code, response

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -671,6 +671,22 @@ class TestStartWithPortBindings(BaseTestCase):
         self.client.kill(id)
 
 
+class TestMacAddress(BaseTestCase):
+    def runTest(self):
+        mac_address_expected = "02:42:ac:11:00:0a"
+        container = self.client.create_container(
+            'busybox', ['sleep', '60'], mac_address=mac_address_expected)
+
+        id = container['Id']
+
+        self.client.start(container)
+        res = self.client.inspect_container(container['Id'])
+        self.assertEqual(mac_address_expected,
+                         res['NetworkSettings']['MacAddress'])
+
+        self.client.kill(id)
+
+
 class TestRestart(BaseTestCase):
     def runTest(self):
         container = self.client.create_container('busybox', ['sleep', '9999'])

--- a/tests/test.py
+++ b/tests/test.py
@@ -768,6 +768,18 @@ class DockerClientTest(Cleanup, unittest.TestCase):
             docker.client.DEFAULT_TIMEOUT_SECONDS
         )
 
+    def test_create_container_with_mac_address(self):
+        try:
+            mac_address_expected = "02:42:ac:11:00:0a"
+            container = self.client.create_container(
+                'busybox', ['sleep', '60'], mac_address=mac_address_expected)
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+
+        res = self.client.inspect_container(container['Id'])
+        self.assertEqual(mac_address_expected,
+                         res['NetworkSettings']['MacAddress'])
+
     def test_create_container_with_links(self):
         try:
             link_path = 'path'


### PR DESCRIPTION
The new docker api allows specifing mac address for containers. This change is to allow docker py the same functionality.

Signed-off-by: James Harris james@rancher.com
